### PR TITLE
Add local build command for static deployments

### DIFF
--- a/operations.py
+++ b/operations.py
@@ -101,7 +101,7 @@ def fetch_from_repo():
         local("wget -O%s '%s'" % (name, url))
 
 
-def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False):
+def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False, build_local_cmd=None):
     """
     Fetch source code, render settings file, push remotely and delete checkout.
 
@@ -131,6 +131,10 @@ def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False):
             except KeyError:
                 # Blow up if the structure isn't as expected.
                 abort("The structure of env.custom_config_files is invalid")
+
+    # Don't try to handle any errors here - the deploy should fail.
+    if build_local_cmd:
+        build_local_cmd(env.tempdir)
 
     if copy_remote:
         rsync_from_local()

--- a/static.py
+++ b/static.py
@@ -1,7 +1,8 @@
 import os
+import utils
 import operations
 
-from fabric.api import env, runs_once, require
+from fabric.api import env, runs_once, require, run, local
 
 @runs_once
 def setup_paths():
@@ -17,5 +18,15 @@ def deploy_static(ref=None, dirty=False):
     """
     Deploy static files to a vhost.
     """
+    build_cmd = create_custom_command(env.require_path, env.build_config)
+    operations.fetch_render_copy(ref, False, dirty, True, build_cmd)
 
-    operations.fetch_render_copy(ref, False, dirty, True)
+def create_custom_command(require_path, build_conf_path):
+    """
+    Create a custom build command for require.js
+    """
+    def build_local_cmd(tempdir):
+        abs_require_path = os.path.join(tempdir, require_path)
+        abs_build_conf_path = os.path.join(tempdir, build_conf_path)
+        local("node %s -o %s" % (abs_require_path, abs_build_conf_path))
+    return build_local_cmd


### PR DESCRIPTION
In order to locally build javascript modules before rsyncing, a create_custom_command function has been added to static.py.

Currently this is focused on invoking require.js (which requires a local installation of node.js). It uses a closure so parameters from the fabfile and env.tempdir can be provided from different contexts.

No errors are handled from local() as the deploy should fail in this case.

As discussed with @dcarley, fetch_render_copy is getting a little out of hand and performs too many functions -- an issue will be created to discuss refactoring this.
