### PR TITLE
Modify template behaviour with env.template_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ A common set of [Fabric](http://fabfile.org) tasks to reduce duplication of code
             { "source": "conf/bar.conf.template", "dest": "conf/bar.conf" }
         ]
 
+- `env.template_key`: Templating format to use. When set to `$` it will use [string.Template](http://docs.python.org/library/string.html#string.Template) to do key/value substitution. When omitted it will fall back to the previous behaviour of `%()s` Python string interpolation.
+
+        env.template_key = '$'
+
 ## Design
 
 I was originally hoping to avoid global `env` variables and have each method accept and return it's own variables. However doing so would mean that they wouldn't be easily callable as standalone Fabric tasks, unless you specified all arguments by hand (like absolute paths) or wrap them in one-to-one classes, which kind of defeats the point of removing duplication. Instead I have attempted to make it clear what global variables each method uses and restrict utility methods for modifying them.

--- a/utils.py
+++ b/utils.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import tempfile
 
-from string import replace
+from string import replace, Template
 from xml.dom import minidom
 
 from fabric.api import env, prompt, runs_once, sudo, local, puts, lcd
@@ -222,10 +222,14 @@ def template_context(vars):
 def template_to_file(source, target, context):
     """
     Populate templated local_settings and place it in the tempdir to be
-    rsynced.
+    rsynced. If `env.template_key = '$'` then it will use string.Template.
+    Otherwise it will fallback to Python `%()s` string interpolation.
     """
 
     with open(target, "w") as target_file:
         with open(source) as source_file:
-            text = source_file.read() % context
+            if env.get('template_key') == '$':
+                text = Template(source_file.read()).substitute(context)
+            else:
+                text = source_file.read() % context
         target_file.write(text)


### PR DESCRIPTION
Can be set to '$' to use normal variable substitutions. Default behaviour
remains old %()s Python string interpolation, which should be phased out.

This is prompted by two things:

a) Maven projects already use `$` for variable replacements. This makes
yellfabric more easy for them to use.
b) The string interpolation is pretty hacky anyway.
## 

@maxlock @grjames @bohnea01a @MentzerK Can you review this ASAP?

/cc @wesamhaboush @esanchezros @simonlewis 
