### PR TITLE
Enable non template resources

### DIFF
--- a/java.py
+++ b/java.py
@@ -57,7 +57,7 @@ def render_settings_template():
 
     for conf_file in os.listdir(source_dir):
         file_name, file_extension = os.path.splitext(conf_file)
-        if file_extension in non_template_exts:
+        if file_extension in env.non_template_exts:
             shutil.copy(os.path.join(source_dir, conf_file),
                          os.path.join(target_dir, conf_file))
         else:

--- a/java.py
+++ b/java.py
@@ -1,6 +1,7 @@
 import glob
 import os.path
 import sys
+import shutil
 import tempfile
 
 from fabric.api import local, env, sudo, runs_once, require
@@ -12,10 +13,10 @@ from utils import template_context, template_to_file
 @runs_once
 def setup_paths():
     require("java_root", "java_conf", "java_log", "project_name")
-    
+
     env.jar_file = "%s.jar" % env.project_name
     env.jar_path = os.path.join(env.jar_root, env.jar_file)
-    
+
     env.war_file = "%s.war" % env.project_name
     env.war_path = os.path.join(env.java_root, env.war_file)
 
@@ -38,6 +39,8 @@ def setup_paths():
 
 @runs_once
 def render_settings_template():
+    non_template_exts = [".jks", ".pkcs12", ".pem", ".crt", ".cer"]
+
     tempdir = tempfile.mkdtemp()
     local("tar -C'%s' -xzf '%s'" % (tempdir, env.app_config_archive))
 
@@ -48,7 +51,12 @@ def render_settings_template():
     context = template_context(env.settings_vars)
 
     for conf_file in os.listdir(source_dir):
-        template_to_file(os.path.join(source_dir, conf_file),
+        file_name, file_extension = os.path.splitext(conf_file)
+        if file_extension in non_template_exts:
+            shutil.copy(os.path.join(source_dir, conf_file),
+                         os.path.join(target_dir, conf_file))
+        else:
+            template_to_file(os.path.join(source_dir, conf_file),
                          os.path.join(target_dir, conf_file),
                          context)
 
@@ -99,7 +107,7 @@ def deploy_java():
         sudo(
             "/usr/local/sbin/deploy_tomcat_webapp.py %s" % env.project_name ,
             shell=False,
-        )        
+        )
 
 def deploy_jar():
     render_settings_template()

--- a/java.py
+++ b/java.py
@@ -39,7 +39,12 @@ def setup_paths():
 
 @runs_once
 def render_settings_template():
-    non_template_exts = [".jks", ".pkcs12", ".pem", ".crt", ".cer"]
+    try:
+        env.non_template_exts
+    except NameError:
+       env.non_template_exts = []
+    except AttributeError:
+       env.non_template_exts = []
 
     tempdir = tempfile.mkdtemp()
     local("tar -C'%s' -xzf '%s'" % (tempdir, env.app_config_archive))


### PR DESCRIPTION
Allow java projects to specify a List of file extensions which should be ignored when resolving templates. Instead they are copied directly to the target folder unmodified.
This means that java projects can deploy binary resources (e.g. keystores) or non-template text resources (e.g. certificates) whose content would clash with the template variable markers.

Projects can specify the exclusion list by setting env.non_template_exts. e.g.:
env.non_template_exts = [".jks", ".p12" ]
