### PR TITLE
Allow load_extdata to take ~/ paths

### DIFF
--- a/operations.py
+++ b/operations.py
@@ -144,6 +144,7 @@ def load_extdata(filename):
     Takes a single CSV file as a mandatory argument.
     """
 
+    filename = os.path.expanduser(filename)
     if not os.path.exists(filename):
         abort("File %r not found" % filename)
 


### PR DESCRIPTION
Call os.path.expanduser to allow ~/ paths to CSV files.
## 

Pinging @maxlock @grjames @bohnea01a @MentzerK
