### PR TITLE
New undeploy_java() command

### DIFF
--- a/java.py
+++ b/java.py
@@ -118,6 +118,16 @@ def deploy_java():
     sudo(cmd, shell=False)
 
 
+def undeploy_java():
+    require("sudo_user", "tomcat_deploy_webapp", "project_name")
+    cmd = "%s %s --action undeploy" % (env.tomcat_deploy_webapp, env.project_name)
+
+    if "tomcat_context_path" in env:
+        cmd += " --context %s" % env.tomcat_context_path
+
+    sudo(cmd, shell=False)
+
+
 def deploy_jar():
     render_settings_template()
 

--- a/java.py
+++ b/java.py
@@ -23,6 +23,8 @@ def setup_paths():
     env.app_config_archive = "%s-config.tar.gz" % env.project_name
     env.sql_archive = "%s-sql.tar.gz" % env.project_name
 
+    env.tomcat_deploy_webapp = "/usr/local/sbin/deploy_tomcat_webapp.py"
+
     try:
        env.config_dir_name
     except NameError:
@@ -107,8 +109,8 @@ def deploy_java():
     require("war_file", "war_path")
     rsync_as_user(env.war_path, env.war_file, env.sudo_user)
 
-    require("project_name")
-    cmd = "/usr/local/sbin/deploy_tomcat_webapp.py %s" % env.project_name
+    require("tomcat_deploy_webapp", "project_name")
+    cmd = "%s %s" % (env.tomcat_deploy_webapp, env.project_name)
 
     if "tomcat_context_path" in env:
         cmd += " --context %s" % env.tomcat_context_path

--- a/java.py
+++ b/java.py
@@ -108,16 +108,13 @@ def deploy_java():
     rsync_as_user(env.war_path, env.war_file, env.sudo_user)
 
     require("project_name")
-    if env.get("tomcat_context_path"):
-        sudo(
-            "/usr/local/sbin/deploy_tomcat_webapp.py %s --context %s" % (env.project_name, env.tomcat_context_path) ,
-            shell=False,
-        )
-    else:
-        sudo(
-            "/usr/local/sbin/deploy_tomcat_webapp.py %s" % env.project_name ,
-            shell=False,
-        )
+    cmd = "/usr/local/sbin/deploy_tomcat_webapp.py %s" % env.project_name
+
+    if "tomcat_context_path" in env:
+        cmd += " --context %s" % env.tomcat_context_path
+
+    sudo(cmd, shell=False)
+
 
 def deploy_jar():
     render_settings_template()


### PR DESCRIPTION
Calls existing `--action undeploy` functionality in deploy_tomcat_webapp.

This doesn't remove the config or original WAR, on the basis that you might
want to retain those.
## 

Pinging: @maxlock @grjames @MentzerK @bohnea01a 
