### PR TITLE
add branch info to scm_info

### DIFF
--- a/operations.py
+++ b/operations.py
@@ -162,9 +162,8 @@ def render_ci_props(scm_type="git"):
     build_props['jenkinsUrl']=jenkins_url
     build_props['sourceControlSystem']=scm_type
     build_props['sourceControlRevision']=scm_revision
-    build_props['branch']=scm_branch
-    build_props['revision']=scm_revision
-    build_props['commit']=scm_commit
+    build_props['sourceControlBranch']=scm_branch
+    build_props['sourceControlCommit']=scm_commit
 
     json_props = json.dumps(build_props)
 

--- a/operations.py
+++ b/operations.py
@@ -140,13 +140,11 @@ def render_ci_props(scm_type="git"):
     scm_type = scm_type.lower()
 
     if(scm_type == "git"):
-        scm_revision = os.environ.get("GIT_REVISION")
+        scm_revision = os.environ.get("GIT_COMMIT")
         scm_branch = os.environ.get("GIT_BRANCH")
-        scm_commit = os.environ.get("GIT_COMMIT")
     if(scm_type == "svn"):
         scm_revision = os.environ.get("SVN_REVISION")
         scm_branch = os.environ.get("SVN_BRANCH")
-        scm_commit = os.environ.get("SVN_COMMIT")
     
     build_props = {}
     build_props['name']=env.project_name
@@ -163,7 +161,6 @@ def render_ci_props(scm_type="git"):
     build_props['sourceControlSystem']=scm_type
     build_props['sourceControlRevision']=scm_revision
     build_props['sourceControlBranch']=scm_branch
-    build_props['sourceControlCommit']=scm_commit
 
     json_props = json.dumps(build_props)
 

--- a/utils.py
+++ b/utils.py
@@ -100,6 +100,7 @@ def scm_get_info(scm_type, scm_ref=None, directory=False):
                         .getAttribute("revision"),
                     "url": dom.getElementsByTagName("url")[0] \
                         .firstChild.wholeText,
+                     "branch": scm_ref,
                 }
 
     elif scm_type.lower() == "git":
@@ -117,6 +118,7 @@ def scm_get_info(scm_type, scm_ref=None, directory=False):
                     "type": scm_type,
                     "rev": revision,
                     "url": repo,
+                    "branch": scm_ref,
                 }
 
     return scm_info
@@ -158,6 +160,7 @@ def fetch_source(scm_type, scm_url, scm_ref=None, dirty=False):
     #
     with lcd(tempdir):
         scm_info = scm_get_info(scm_type, scm_ref, tempdir)
+
         filename = "version"
         local("echo \"%s\" > %s" \
             % (

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ import context_managers
 import os
 import shutil
 import tempfile
+import json
 
 from string import replace, Template
 from xml.dom import minidom
@@ -160,18 +161,15 @@ def fetch_source(scm_type, scm_url, scm_ref=None, dirty=False):
     #
     with lcd(tempdir):
         scm_info = scm_get_info(scm_type, scm_ref, tempdir)
+        json_info = json.dumps(scm_info)
 
-        filename = "version"
-        local("echo \"%s\" > %s" \
-            % (
-                replace(
-                    str(scm_info),
-                    ' (fetch)',
-                    '',
-                ),
-                filename,
-            )
-        )
+        # remove (fetch) string
+        json_info = json_info.replace(' (fetch)', '')
+        # remove tab character after origin
+        json_info = json_info.replace('\\t', ' ')
+
+        version_file = open("version", "w")
+        version_file.write(json_info)
 
     if "scm_path" in env:
         tempdir = os.path.join(tempdir, env.scm_path)


### PR DESCRIPTION
Added details of branch in version file on fabric deployment so this can be used to report which branch the code was deployed from.

Eg.
    {'url': 'origin git@github.com:YellLabs/eventsapi.git', 'rev': '928f3c6', 'type': 'git', 'branch': 'master'}
