### PR TITLE
Add module for deploying Play Framework 2.x projects

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -12,6 +12,7 @@ env.java_conf = "/etc/yell"
 env.java_log = "/var/log/tomcat6"
 env.play_root = "/srv/play"
 env.play_bin = "/opt/play/play"
+env.play2_root = "/srv/play2"
 
 # Disable bash login simulation. It generates errors when used with sudo
 # because the sudo'ed user doesn't have access to the original user's

--- a/operations.py
+++ b/operations.py
@@ -32,6 +32,8 @@ def fab_setup_paths():
         glassfish.setup_paths()
     elif env.lang == "play":
         play.setup_paths()
+    elif env.lang == "play2":
+        play2.setup_paths()
     elif env.lang == "static":
         static.setup_paths()
     else:

--- a/operations.py
+++ b/operations.py
@@ -2,6 +2,7 @@ import java
 import python
 import glassfish
 import play
+import play2
 import static
 import utils
 
@@ -47,9 +48,12 @@ def scm_echo_info():
     pprint.pprint(utils.scm_get_info(env.scm_type))
 
 
-def rsync_from_local():
+def rsync_from_local(local_path):
     """
     Push a local checkout of the code to a remote machine.
+
+    local_subdir specifies the subdirectory of the project to be
+    synced (e.g. build/).
     """
 
     require("tempdir", "project_path", "sudo_user")
@@ -64,7 +68,7 @@ def rsync_from_local():
         rsync_opts = '--rsync-path="sudo -u %s rsync"' % env.sudo_user
 
     rsync_project(
-        local_dir="%s/" % env.tempdir,
+        local_dir=os.path.join(env.tempdir, local_path),
         remote_dir="%s/" % env.project_path,
         exclude=rsync_exclude,
         delete=True,
@@ -104,7 +108,8 @@ def fetch_from_repo():
         local("wget -O%s '%s'" % (name, url))
 
 
-def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False, build_local_cmd=None):
+def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False,
+                      build_local_cmd=None, local_path=""):
     """
     Fetch source code, render settings file, push remotely and delete checkout.
     """
@@ -124,7 +129,7 @@ def fetch_render_copy(ref=None, debug=False, dirty=False, copy_remote=False, bui
         build_local_cmd(env.tempdir)
 
     if copy_remote:
-        rsync_from_local()
+        rsync_from_local(local_path)
 
     utils.delete_source_conditional(env.tempdir, dirty)
 

--- a/play2.py
+++ b/play2.py
@@ -1,0 +1,106 @@
+import os
+import context_managers
+import utils
+import operations
+
+from fabric.api import env, require, cd, runs_once, sudo, abort, local, lcd
+
+def create_custom_command(play_bin, zip_bin="unzip"):
+    """
+    Packages the project using `play dist` and unzips the resulting file.
+
+    The lib/ directory contains all project code and deps.
+
+    Assumes play_bin is the play 2 binary.
+
+    Resulting function takes a 'tempdir' arg to match the definition in static.py
+    """
+
+    require("project_name", "project_version")
+    def local_build_command(tempdir):
+        with lcd(tempdir):
+            local("%s dist" % (play_bin))
+            with lcd("dist"):
+                local("%s %s-%s.zip" % (zip_bin, env.project_name, env.project_version))
+    return local_build_command
+
+
+@runs_once
+def setup_paths():
+    require("play2_root", "project_name")
+
+    env.project_path = os.path.join(env.play2_root, env.project_name)
+    env.config_source = os.path.join("conf", "application.conf.template")
+    env.config_target = os.path.join("conf", "application.conf")
+
+
+def tail(stderr=False):
+    """
+    Tail the output of an application using supervisord.
+
+    stderr argument can be supplied to return STDERR instead of STDOUT.
+    """
+
+    require("project_name")
+
+    cmd = "supervisorctl tail play2-%s" % env.project_name
+
+    if stderr:
+        cmd += " stderr"
+
+    sudo(cmd, shell=False)
+
+
+def status():
+    """
+    Query the status of an application using supervisord.
+    """
+
+    require("project_name")
+
+    cmd = "supervisorctl status play2-%s" % env.project_name
+    sudo(cmd, shell=False)
+
+
+def restart():
+    """
+    Restart the application using supervisord.
+    """
+
+    require("project_name")
+
+    cmd = "supervisorctl restart play2-%s" % env.project_name
+    sudo(cmd, shell=False)
+
+
+def start_play():
+    """
+    Start the play application.
+    """
+
+    require("project_name")
+
+    cmd = "supervisorctl start play2-%s" % env.project_name
+    sudo(cmd, shell=False)
+
+    
+def stop_play():
+    """
+    Stop the currently running play application.
+    """
+
+    require("project_name")
+
+    cmd = "supervisorctl stop play2-%s" % env.project_name
+    sudo(cmd, shell=False)
+
+def deploy_play2(ref=None, debug=False, dirty=False):
+    """
+    Standard Play 2 deployment actions.
+    """
+
+    require("project_name", "project_version", "play2_bin")
+    build_cmd = create_custom_command(env.play2_bin)
+    local_build_path = os.path.join("dist/", ''.join([env.project_name, '-', env.project_version]))
+    operations.fetch_render_copy(ref, debug, dirty, True, build_cmd, local_build_path)
+    restart()

--- a/play2.py
+++ b/play2.py
@@ -5,12 +5,13 @@ import operations
 
 from fabric.api import env, require, cd, runs_once, sudo, abort, local, lcd
 
-def create_custom_command():
+def create_custom_command(dist):
     """
     Creates a custom build command executed in operations.fetch_render_copy
     """
     def build_cmd(tempdir):
-        package_dist()
+        if dist:
+            package_dist()
         extract_project()
     return build_cmd
 
@@ -114,10 +115,7 @@ def deploy_play2(ref=None, debug=False, dirty=False, dist=False):
     """
 
     require("project_name", "project_version")
-    if dist:
-        require("play2_bin")
-
-    build_cmd = create_custom_command()
+    build_cmd = create_custom_command(dist)
     local_build_path = os.path.join("dist", ''.join([env.project_name, '-', env.project_version, os.sep]))
     operations.fetch_render_copy(ref, debug, dirty, True, build_cmd, local_build_path)
     restart()

--- a/play2.py
+++ b/play2.py
@@ -1,9 +1,7 @@
 import os
-import context_managers
-import utils
 import operations
 
-from fabric.api import env, require, cd, runs_once, sudo, abort, local, lcd
+from fabric.api import env, require, runs_once, sudo, local, lcd
 
 def create_custom_command(dist):
     """
@@ -116,6 +114,9 @@ def deploy_play2(ref=None, debug=False, dirty=False, dist=False):
 
     require("project_name", "project_version")
     build_cmd = create_custom_command(dist)
-    local_build_path = os.path.join("dist", ''.join([env.project_name, '-', env.project_version, os.sep]))
-    operations.fetch_render_copy(ref, debug, dirty, True, build_cmd, local_build_path)
+    local_build_path = os.path.join("dist",
+                                        ''.join([env.project_name,
+                                        '-', env.project_version, os.sep]))
+    operations.fetch_render_copy(ref, debug, dirty, True,
+                                     build_cmd, local_build_path)
     restart()

--- a/play2.py
+++ b/play2.py
@@ -101,6 +101,6 @@ def deploy_play2(ref=None, debug=False, dirty=False):
 
     require("project_name", "project_version", "play2_bin")
     build_cmd = create_custom_command(env.play2_bin)
-    local_build_path = os.path.join("dist/", ''.join([env.project_name, '-', env.project_version]))
+    local_build_path = os.path.join("dist", ''.join([env.project_name, '-', env.project_version, os.sep]))
     operations.fetch_render_copy(ref, debug, dirty, True, build_cmd, local_build_path)
     restart()


### PR DESCRIPTION
Adds the `play2` module for deploying projects using Play Framework 2.x

This functions in a similar fashion the the `play` module, however, there are some differences.
- `play dist` is invoked as a local build command. This produces a zip file in `dist/` with all project dependencies.
- This zip file is unzipped and rsynced to the project deployment directory

In order to only sync the files in `dist/{project-name}-{project-version}/`, an argument has been added to `rsync_from_local` to specify this.

Adding yet another argument to `rsync_from_local` (and thus to its caller, `fetch_render_copy`) is not particularly neat, so it would be good to start a discussion at some point on how we can tidy this module up.

There is also a fair bit of overlap between the `play` and `play2` functions for `supervisord` control, so it would be a good idea for these to be extracted into a separate generic module in future.
