### PR TITLE
Remove double config rsync for Java apps

### DIFF
--- a/java.py
+++ b/java.py
@@ -25,17 +25,7 @@ def setup_paths():
 
     env.tomcat_deploy_webapp = "/usr/local/sbin/deploy_tomcat_webapp.py"
 
-    try:
-       env.config_dir_name
-    except NameError:
-       env.config_dir_name = None
-    except AttributeError:
-       env.config_dir_name = None
-
-    if env.config_dir_name is None:
-       env.config_dir_name = env.project_name
-    env.app_config_dir = os.path.join(env.java_conf, env.config_dir_name)
-    env.app_xml_config_dir = os.path.join(env.java_conf, env.project_name)
+    env.app_config_dir = os.path.join(env.java_conf, env.get("config_dir_name", "project_name"))
     env.log_dir = os.path.join(env.java_log, env.project_name)
 
 
@@ -96,14 +86,6 @@ def deploy_java():
         "%s/" % env.deploy_config_dir,
         env.sudo_user,
         delete=True,
-    )
-
-    require("app_xml_config_dir", "deploy_config_dir")
-    rsync_as_user(
-        "%s/" % env.app_xml_config_dir,
-        "%s/" % env.deploy_config_dir,
-        env.sudo_user,
-        delete=True
     )
 
     require("war_file", "war_path")


### PR DESCRIPTION
This was introduced in a43cc202 (along with a separate unrelated feature).

However it didn't test whether app_config_dir and app_xml_config_dir were
actually the same path. Resulting, for most cases, in the same rsync command
being run twice.

I'm slimming this down by allowing env.config_dir_name to override the
config path but otherwise falling back to env.project_name, then removing
the second rsync altogether.

This shouldn't introduce any regressions. But if it does, it will only by
for applications that are no longer in use or development.
