### PR TITLE
(#20) Pin to Fabric 1.4 due to sudo_user issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-Fabric >= 1.2.0
+# Sticking with 1.4 due to issue #20
+Fabric < 1.5.0


### PR DESCRIPTION
Fabric 1.5 introduced a special meaning to env.sudo_user which we were
already using in places. Mitigate this issue by pinning to Fabric 1.4 and
lower for the time being.
