### PR TITLE
(RM4888) Catch supervisorctl and Play deps errors

### DIFF
--- a/play.py
+++ b/play.py
@@ -17,6 +17,8 @@ def setup_paths():
 def sync_deps():
     """
     Download project dependencies and sync modules/lib dirs.
+
+    Abort if there are any missing dependencies.
     """
 
     require(
@@ -26,7 +28,10 @@ def sync_deps():
         "sudo_user",
     )
     with context_managers.proxy(env.http_proxy, env.https_proxy):
-        utils.play_run(env.project_path, "dependencies --sync", user=env.sudo_user)
+        out = utils.play_run(env.project_path, "dependencies --sync", user=env.sudo_user)
+
+    if "WARNING" in out:
+        abort("Missing dependencies")
 
 
 def tail(stderr=False):

--- a/play.py
+++ b/play.py
@@ -53,8 +53,7 @@ def status():
 
     require("project_name")
 
-    cmd = "supervisorctl status play-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("status", "play-%s" % env.project_name)
 
 
 def restart():
@@ -64,8 +63,7 @@ def restart():
 
     require("project_name")
 
-    cmd = "supervisorctl restart play-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("restart", "play-%s" % env.project_name)
 
 
 def start_play():
@@ -75,8 +73,7 @@ def start_play():
 
     require("project_name")
 
-    cmd = "supervisorctl start play-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("start", "play-%s" % env.project_name)
 
     
 def stop_play():
@@ -86,8 +83,7 @@ def stop_play():
 
     require("project_name")
 
-    cmd = "supervisorctl stop play-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("stop", "play-%s" % env.project_name)
 
 
 @runs_once

--- a/play2.py
+++ b/play2.py
@@ -71,8 +71,7 @@ def status():
 
     require("project_name")
 
-    cmd = "supervisorctl status play2-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("status", "play2-%s" % env.project_name)
 
 
 def restart():
@@ -82,8 +81,7 @@ def restart():
 
     require("project_name")
 
-    cmd = "supervisorctl restart play2-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("restart", "play2-%s" % env.project_name)
 
 
 def start_play():
@@ -93,8 +91,7 @@ def start_play():
 
     require("project_name")
 
-    cmd = "supervisorctl start play2-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("start", "play2-%s" % env.project_name)
 
     
 def stop_play():
@@ -104,8 +101,7 @@ def stop_play():
 
     require("project_name")
 
-    cmd = "supervisorctl stop play2-%s" % env.project_name
-    sudo(cmd, shell=False)
+    utils.supervisorctl("stop", "play2-%s" % env.project_name)
 
 def deploy_play2(ref=None, debug=False, dirty=False, dist=False):
     """

--- a/utils.py
+++ b/utils.py
@@ -52,7 +52,7 @@ def play_run(path, command, user):
         # Make absolutely sure resulting directories are readable by the
         # the Play process which runs as a different user.
         with prefix('umask 0002'):
-            sudo(cmd, user=user)
+            return sudo(cmd, user=user)
 
 
 def supervisorctl(command, name):

--- a/utils.py
+++ b/utils.py
@@ -55,6 +55,15 @@ def play_run(path, command, user):
             sudo(cmd, user=user)
 
 
+def supervisorctl(command, name):
+    """
+    Run a supervisorctl action against a given project.
+    """
+
+    cmd = "supervisorctl %s %s" % (command, name)
+    sudo(cmd, shell=False)
+
+
 @runs_once
 def scm_get_ref(scm_type, use_default=False):
     if scm_type.lower() == "svn":

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,7 @@ import json
 from string import replace, Template
 from xml.dom import minidom
 
-from fabric.api import env, prompt, runs_once, sudo, local, puts, lcd
+from fabric.api import env, prompt, runs_once, sudo, local, puts, lcd, abort
 from fabric.context_managers import hide, cd, prefix
 #from fabric.contrib.files import append
 
@@ -58,10 +58,20 @@ def play_run(path, command, user):
 def supervisorctl(command, name):
     """
     Run a supervisorctl action against a given project.
+
+    Abort if the output contains ERROR.
     """
 
     cmd = "supervisorctl %s %s" % (command, name)
-    sudo(cmd, shell=False)
+    out = sudo(cmd, shell=False)
+
+    if command == "restart":
+        # We only care about the last item which is start.
+        out = out.split("\n")[-1]
+
+    # Supervisorctl doesn't support exit codes.
+    if "ERROR" in out:
+        abort(out)
 
 
 @runs_once


### PR DESCRIPTION
The `supervisorctl` utility doesn't return the expected exit codes when a process fails to start (or stop/restart). This causes the errors to be missed by Fabric.

Parse the output and `abort()` if this happens.

Likewise for `play dependencies --sync` which always exits with `0`.
