### PR TITLE
File 'version' is created in the directory that is rsynced to the server

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -187,7 +187,7 @@ def fetch_source(scm_type, scm_url, scm_ref=None, dirty=False):
         # remove tab character after origin
         json_info = json_info.replace('\\t', ' ')
 
-        version_file = open("version", "w")
+        version_file = open(os.path.join(tempdir, "version"), "w")
         version_file.write(json_info)
 
     if "scm_path" in env:


### PR DESCRIPTION
Fixes an issue in yellfabric. 'version' (the file with SCM information) was created in the project folder and then the temp folder was rsynced to the server.

If the deployment uses 'dirty=True' that is not a problem because the temp folder is the project folder, but, for a non-dirty deployment, this means that 'version' doesn't make it to the server and in the version page, the user gets {"Error": "build info not available"}

This has been unnoticed until now because there is another file (ci_props.json) that takes precedence over 'version' and, probably, because most deployments use 'dirty=True' anyway.
