### PR TITLE
copying version file to the server for play2 deployments as well

### DIFF
--- a/play2.py
+++ b/play2.py
@@ -1,6 +1,7 @@
 import os
 import operations
 import utils
+from shutil import copy
 
 from fabric.api import env, require, runs_once, sudo, local, lcd, abort
 
@@ -28,8 +29,10 @@ def extract_project(zip_bin="unzip"):
         
         # adding the version file to the folder rsynced with server
         version_file_dir = os.path.join(env.tempdir, "dist/%s-%s" % (env.project_name, env.project_version))
-        local("pwd")
-        local("cp %s/version %s/version" % (env.tempdir, version_file_dir))        
+
+        src = "%s/version" % env.tempdir
+        dst = "%s/version" % version_file_dir
+        copy(src, dst)
 
 
 def package_dist():

--- a/play2.py
+++ b/play2.py
@@ -25,6 +25,11 @@ def extract_project(zip_bin="unzip"):
     require("project_name", "project_version", "tempdir")
     with lcd(os.path.join(env.tempdir,"dist")):
         local("%s %s-%s.zip" % (zip_bin, env.project_name, env.project_version))
+        
+        # adding the version file to the folder rsynced with server
+        version_file_dir = os.path.join(env.tempdir, "dist/%s-%s" % (env.project_name, env.project_version))
+        local("pwd")
+        local("cp %s/version %s/version" % (env.tempdir, version_file_dir))        
 
 
 def package_dist():

--- a/utils.py
+++ b/utils.py
@@ -187,7 +187,7 @@ def fetch_source(scm_type, scm_url, scm_ref=None, dirty=False):
         # remove tab character after origin
         json_info = json_info.replace('\\t', ' ')
 
-        version_file = open("version", "w")
+        version_file = open(os.path.join(tempdir,"version"), "w")
         version_file.write(json_info)
 
     if "scm_path" in env:


### PR DESCRIPTION
copying version file to the server for play2 deployments as well.
this allows play2 apps to expose the /version endpoint to show running code infos.
