### PR TITLE
Added boto (aws sdk) as a python requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # Sticking with 1.4 due to issue #20
 Fabric < 1.5.0
+boto==2.8.0


### PR DESCRIPTION
Have added in boto http://boto.readthedocs.org/en/latest/index.html as a requirement. 

This allows us to use it in our fabfile custom tasks without needing extra requirements per project.
