### PR TITLE
Defaults to stdout in play2-tail

### DIFF
--- a/play2.py
+++ b/play2.py
@@ -69,6 +69,8 @@ def tail(stderr=False):
 
     if stderr:
         cmd += " stderr"
+    else:
+        cmd += " stdout"
 
     sudo(cmd, shell=False)
 

--- a/play2.py
+++ b/play2.py
@@ -67,10 +67,16 @@ def tail(stderr=False):
 
     cmd = "supervisorctl tail play2-%s" % env.project_name
 
-    if stderr:
-        cmd += " stderr"
-    else:
-        cmd += " stdout"
+    # If 'stderr' is supplied via command line, check its validity
+    if stderr == 'True':
+        stderr = True
+    if stderr == 'False':
+        stderr = False
+    # If we've failed to produce a boolean flag, abort
+    if stderr is not True and stderr is not False:
+        abort('stderr argument must equal True or False')
+
+    cmd += " stderr" if stderr else " stdout"
 
     sudo(cmd, shell=False)
 


### PR DESCRIPTION
Running 'tail' for a play2 project without parameters does not default to stdout like intended. Instead, It prints:

```
    error: <class 'xml.parsers.expat.ExpatError'>, not well-formed (invalid token): line 6, column 1: file: /usr/lib/python2.7/xmlrpclib.py line: 557
    Fatal error: sudo() received nonzero return code 2 while executing!
```

This commit fixes that and does not change the behaviour when an argument is provided.
