### PR TITLE
Deploy play2 not dist

### DIFF
--- a/play2.py
+++ b/play2.py
@@ -12,9 +12,16 @@ def create_custom_command(dist):
     def build_cmd(tempdir):
         if dist is True:
             package_dist()
-        extract_project()
+            extract_project()
+        else:
+            stage_project()
     return build_cmd
 
+def stage_project():
+    # Follows best practice as of http://www.playframework.com/documentation/2.0/Production
+    require("play2_bin", "tempdir")
+    with lcd(env.tempdir):
+        local("%s clean compile stage" % (env.play2_bin))
 
 def extract_project(zip_bin="unzip"):
     """
@@ -136,9 +143,13 @@ def deploy_play2(ref=None, debug=False, dirty=False, dist=False):
 
     require("project_name", "project_version")
     build_cmd = create_custom_command(dist)
-    local_build_path = os.path.join("dist",
+
+    local_build_path= ""
+    if dist:
+        local_build_path = os.path.join("dist",
                                         ''.join([env.project_name,
                                         '-', env.project_version, os.sep]))
+
     operations.fetch_render_copy(ref, debug, dirty, True,
                                      build_cmd, local_build_path)
     restart()

--- a/play2.py
+++ b/play2.py
@@ -67,10 +67,16 @@ def tail(stderr=False):
 
     cmd = "supervisorctl tail play2-%s" % env.project_name
 
-    if stderr:
-        cmd += " stderr"
-    else:
-        cmd += " stdout"
+    # If 'stderr' is supplied via command line, check its validity
+    if stderr == 'True':
+        stderr = True
+    if stderr == 'False':
+        stderr = False
+    # If we've failed to produce a boolean flag, abort
+    if stderr is not True and stderr is not False:
+        abort('stderr argument must equal True or False')
+
+    cmd += " stderr" if stderr else " stdout"
 
     sudo(cmd, shell=False)
 


### PR DESCRIPTION
Previously, the only way to deploy a Play 2 application was the stand-alone mode with `dist=True` ([See doc](http://www.playframework.com/documentation/2.0/ProductionDist)).

This pull request keeps the previous behaviour when `dist=True` but also adds support for standard deployment ([See doc](http://www.playframework.com/documentation/2.0/Production)).

**Note**: This pull request assumes that #38 has being already merged. Review and merge pull request #38 before this one.
